### PR TITLE
Adding jq dependency

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -40,6 +40,7 @@ deps:
   - name: curl
   apt_get:
   - name: curl
+  - name: jq
 
 inputs:
   - app_apk_path: $BITRISE_APK_PATH


### PR DESCRIPTION
When i tried to use the step on my BitRise workflow it complained about the lack of `jq` command.
Running `apt install jq` before it seems to solve the problem